### PR TITLE
修复Rate组件在disable状态下未激活图标的颜色不一致

### DIFF
--- a/uview-ui/components/u-rate/u-rate.vue
+++ b/uview-ui/components/u-rate/u-rate.vue
@@ -11,6 +11,7 @@
 				}"
 				:custom-prefix="customPrefix"
 				:show-decimal-icon="showDecimalIcon(index)"
+        		:inactive-color="inactiveColor"
 				:percent="decimal"
 				:inactive-color="inactiveColor"
 			></u-icon>


### PR DESCRIPTION
1. 设置disable为ture
2. 设置自定义的inactive-color
3. 设置current值为整数
这时会出现未激活的图标有两种颜色